### PR TITLE
Added subfolder creation in /bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ $(BIN_DIR):
 
 $(BIN_DIR)/%.o: $(SRC_DIR)/%.$(SRC_EXT) | $(BIN_DIR)
 	@printf "\e[32;1m+++ $@ -- [$(CXXFLAGS)] \e[0m\n"
+	@mkdir -p $(@D)
 	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 clean:


### PR DESCRIPTION
If compiling sources with different folders, for example: `main.cpp & /class/example.cpp`,  the compiler will try to get the object of `example.cpp` from `./bin/[SUBDIRECTORY]/example.o` (which doesn't exist) and it won't compile.

This fixes it by creating the necessary subdirectories of the sources inside /bin ( for this example: `/bin/[SUBDIRECTORY]/` ), so the object can be placed correctly and the compiler can find.